### PR TITLE
List each deleted file during remove_remote_files

### DIFF
--- a/lemonsync/Utils.py
+++ b/lemonsync/Utils.py
@@ -244,6 +244,7 @@ class Utils ():
 		# rest the remote theme
 		for key in keys:
 			key.delete()
+			print(Fore.RED + '[' + time.strftime("%c") + '] Successfully deleted ' + key.name.replace(path, '') + Style.RESET_ALL)
 
 		return
 


### PR DESCRIPTION
When performing a remote reset where there are several files in S3, the user might wonder if the reset is actually taking place. 

LemonSync should list out each file it removes so its progress is known.
